### PR TITLE
Fix sed -i arg

### DIFF
--- a/src/Development/Shakers.hs
+++ b/src/Development/Shakers.hs
@@ -218,7 +218,7 @@ sed_ d = cmdArgsDir_ d "sed"
 -- | replace inline command.
 --
 replace :: FilePath -> FilePath -> String -> String -> Action ()
-replace d f a b = sed_ d [ "--in-place=.bak", "s" </> a </> b </> "g", f ]
+replace d f a b = sed_ d [ "-i.bak", "s" </> a </> b </> "g", f ]
 
 -- | Git command in a directory.
 --

--- a/src/Development/Shakers.hs
+++ b/src/Development/Shakers.hs
@@ -218,7 +218,7 @@ sed_ d = cmdArgsDir_ d "sed"
 -- | replace inline command.
 --
 replace :: FilePath -> FilePath -> String -> String -> Action ()
-replace d f a b = sed_ d [ "-i", ".bak", "s" </> a </> b </> "g", f ]
+replace d f a b = sed_ d [ "--in-place=.bak", "s" </> a </> b </> "g", f ]
 
 -- | Git command in a directory.
 --


### PR DESCRIPTION
The command `sed -i .bak OTHER_ARGS` fails in Linux. It should be `sed -i.bak OTHER_ARGS` .

To remove the ambiguity replace it with  `sed --in-place=.bak OTHER_ARGS`

@mfine  Can you test this on OSX?