### PR TITLE
Rename repl to ghci

### DIFF
--- a/src/Development/Shakers.hs
+++ b/src/Development/Shakers.hs
@@ -429,14 +429,14 @@ stackRules dir pats = do
   phony "tests-error" $
     stack_ dir [ "build", "--fast", "--test", "--ghc-options=-Werror" ]
 
-  -- repl
+  -- ghci
   --
-  phony "repl" $
+  phony "ghci" $
     stack_ dir [ "ghci" ]
 
-  -- repl-tests
+  -- ghci-tests
   --
-  phony "repl-tests" $
+  phony "ghci-tests" $
     stack_ dir [ "ghci", "--test" ]
 
   -- docs


### PR DESCRIPTION
Sync up the name for reaching `ghci` with the one for targets. Fixes #6.

/cc @ekalosak 